### PR TITLE
Fix currency display on index tables

### DIFF
--- a/src/CurrencyVAT.php
+++ b/src/CurrencyVAT.php
@@ -16,7 +16,7 @@ class CurrencyVAT extends Currency
         parent::__construct($name, $attribute, $resolveCallback);
 
         $novaRequest = app()->make(NovaRequest::class);
-        if ($novaRequest->isResourceDetailRequest() || $novaRequest->isResourceDetailRequest()) {
+        if ($novaRequest->isResourceIndexRequest() || $novaRequest->isResourceDetailRequest()) {
             $this->component = 'currency-field';
         }
 


### PR DESCRIPTION
Allows the default currency field to render as well on resource index listing tables.